### PR TITLE
add hints for `@[symm]` for each of `IsLink.symm`, `Adj.symm`, and `VertexConnected.symm`

### DIFF
--- a/Matroid/Graph/Basic.lean
+++ b/Matroid/Graph/Basic.lean
@@ -153,6 +153,7 @@ lemma eq_or_disjoint_of_mem (hx : x ∈ V(G)) (hy : y ∈ V(G)) : x = y ∨ Disj
 lemma IsLink.edge_mem (h : G.IsLink e x y) : e ∈ E(G) :=
   (edge_mem_iff_exists_isLink ..).2 ⟨x, y, h⟩
 
+@[symm]
 protected lemma IsLink.symm (h : G.IsLink e x y) : G.IsLink e y x :=
   G.isLink_symm h.edge_mem h
 
@@ -380,6 +381,7 @@ lemma Inc.isLoopAt_or_isNonloopAt (h : G.Inc e x) : G.IsLoopAt e x ∨ G.IsNonlo
 /-- `G.Adj x y` means that `G` has an edge whose ends are the vertices `x` and `y`. -/
 def Adj (G : Graph α β) (x y : α) : Prop := ∃ e, G.IsLink e x y
 
+@[symm]
 protected lemma Adj.symm (h : G.Adj x y) : G.Adj y x :=
   ⟨_, h.choose_spec.symm⟩
 

--- a/Matroid/Graph/Connected/Defs.lean
+++ b/Matroid/Graph/Connected/Defs.lean
@@ -307,6 +307,7 @@ def VertexConnected (G : Graph α β) (x y : α) : Prop :=
 lemma VertexConnected.refl (hx : x ∈ V(G)) : G.VertexConnected x x :=
   ⟨G.walkable x, walkable_isCompOf hx, mem_walkable hx, mem_walkable hx⟩
 
+@[symm]
 lemma VertexConnected.symm (h : G.VertexConnected x y) : G.VertexConnected y x := by
   obtain ⟨H, hH, hx, hy⟩ := h
   exact ⟨H, hH, hy, hx⟩


### PR DESCRIPTION
This allows one to use the `symm` tactic on each of `IsLink`, `Adj`, `VertexConnected`.
For example, if the proof state contains a hypothesis `h : G.IsLink e x y`, one can run `symm at h` to change `h` to `h : G.IsLink e y x`. 