### PR TITLE
Re-integrate HamiltonianCycle into main

### DIFF
--- a/Matroid/Exercises/HamiltonianCycle.lean
+++ b/Matroid/Exercises/HamiltonianCycle.lean
@@ -1484,34 +1484,42 @@ lemma Hamiltonian_alpha_kappa [G.Simple] [G.Finite] (h3 : 3 ≤ V(G).encard)
 
 
 
+omit [DecidableEq α] in
+lemma components_encard_le (G : Graph α β)
+    : G.Components.encard ≤ V(G).encard := by
+  have h_disj := G.components_pairwise_stronglyDisjoint
+  have h_eq := G.eq_sUnion_components
+  replace h_eq : V(G) = ⋃ H ∈ G.Components, V(H) := by
+    apply congr_arg (fun H : Graph α β ↦ V(H)) at h_eq
+    simp_all
+  let surj : V(G) → G.Components := by
+    rintro ⟨x, hx⟩
+    refine ⟨G.walkable x, walkable_isCompOf hx⟩
+  have surj_surjective : Function.Surjective surj := by
+    rintro ⟨H, H_spec⟩
+    have H_nonempty := H_spec.1.2
+    have ⟨x, hxH⟩ := H_nonempty
+    have hxG : x ∈ V(G) := H_spec.1.1.le.vertex_subset hxH
+    use ⟨x, hxG⟩
+    simp [surj]
+    simp [H_spec.eq_walkable_of_mem_walkable hxH]
+  have inj_spec := Function.injective_surjInv surj_surjective
+  set inj := Function.surjInv surj_surjective
+  exact Function.Embedding.encard_le ⟨inj, inj_spec⟩
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-lemma finite_components_of_finite (hFinite : G.Finite) :
-  G.Components.Finite := by
-  sorry
+omit [DecidableEq α] in
+lemma finite_components_of_finite {G : Graph α β} (hFinite : G.Finite) :
+    G.Components.Finite := by
+  refine hFinite.vertexSet_finite.finite_of_encard_le ?_
+  exact G.components_encard_le
 
 /- Step 1: WTS G is connected.
 Proof: Suppose not. Then the degree of any vertex in the smallest component C of G
 would be less than |C| ≤ n/2.
 -/
 
-
-lemma thm1_1_connected [G.Simple] [hFinite : G.Finite]
+omit [DecidableEq α] in
+lemma thm1_1_connected {G : Graph α β} [G.Simple] [hFinite : G.Finite]
   (hV : 3 ≤ V(G).ncard) (hDegree : V(G).ncard ≤ 2 * G.minDegree) :
   G.Connected := by
   have encard_eq_ncard : V(G).encard = ↑V(G).ncard := by

--- a/Matroid/Exercises/HamiltonianCycle.lean
+++ b/Matroid/Exercises/HamiltonianCycle.lean
@@ -377,6 +377,15 @@ lemma IsTree.exists_length_two_path
   have hne_xz : x ≠ z := hez.adj.ne
   tauto
 
+-- the same as previous lemma, just reworded
+lemma IsTree.exists_nontrivial_path
+    {T : Graph α β} (hT : T.IsTree) (hV : 3 ≤ V(T).encard) :
+    ∃ P, T.IsPath P ∧ P.Nontrivial := by
+  obtain ⟨P, P_isPath, P_length⟩ := hT.exists_length_two_path hV
+  refine ⟨P, P_isPath, ?_⟩
+  rw [←WList.two_le_length_iff]
+  omega
+
 lemma IsTree.exists_isSepSet
     {T : Graph α β} (hT : T.IsTree) (hV : 3 ≤ V(T).encard) :
     ∃ S, IsSepSet T S ∧ S.encard = 1 := by

--- a/Matroid/Exercises/HamiltonianCycle.lean
+++ b/Matroid/Exercises/HamiltonianCycle.lean
@@ -6,6 +6,7 @@ import Matroid.Graph.Independent
 import Matroid.Graph.Tree
 import Matroid.ForMathlib.Minimal
 import Matroid.Graph.Walk.Index
+import Matroid.ForMathlib.Tactic.ENatToNat
 -- TODO: remember to remove this Loogle import at the end of the project
 import Loogle.Find
 

--- a/Matroid/Exercises/HamiltonianCycle.lean
+++ b/Matroid/Exercises/HamiltonianCycle.lean
@@ -245,6 +245,8 @@ lemma ge_two_components_of_not_connected (hNeBot : G.NeBot) (h : ¬ G.Connected)
   obtain ⟨ H₁, hH1, hvH1 ⟩ := G.exists_IsCompOf_vertex_mem hw
   have : H ≠ H₁ := by sorry
   sorry
+  -- Set.Nontrivial, Set.Subsingleton
+
 
 def ConnectivityGE (G : Graph α β) (k : ℕ∞) : Prop :=
   ∀ S, S.encard < k → (G - S).Connected
@@ -1663,3 +1665,59 @@ lemma exists_left_edge
     (w : WList α β) {x : α} (hxw : x ∈ w) (hx : x ≠ w.first) :
     ∃ e y, w.DInc e y x := by
   sorry
+
+-- cycles in simple graphs are nontrivial
+omit [DecidableEq α] in
+lemma IsCycle.nontrivial_of_simple
+    [G.Simple]
+    {P} (hP : G.IsCycle P) : P.Nontrivial := by
+  obtain (h|h) := hP.loop_or_nontrivial
+  swap; assumption
+  exfalso
+  obtain ⟨x,e,rfl⟩ := h
+  replace hP := hP.isTrail
+  rw [cons_isTrail_iff] at hP
+  apply hP.2.1.ne; simp
+
+-- cycles in simple graphs are of length at least 3
+lemma IsCycle.cycle_length_ge_3_of_simple
+    [G.Simple]
+    {P} (hP : G.IsCycle P) :
+    3 ≤ P.length := by
+  by_contra! hyp_contra
+  replace hyp_contra : P.length = 2 := by
+    suffices 2 ≤ P.length by linarith
+    have P_nontrivial := hP.nontrivial_of_simple
+    linarith [P_nontrivial.one_lt_length]
+  rw [hP.length_eq_two_iff] at hyp_contra
+  obtain ⟨x,y,e,f,_, hne, rfl⟩ := hyp_contra
+  have h_e_link : G.IsLink e x y := by
+    replace hP := hP.isTrail
+    simp_all
+  have h_f_link : G.IsLink f y x := by
+    replace hP := hP.isTrail
+    simp_all
+  symm at h_f_link
+  apply hne
+  have := IsLink.unique_edge h_e_link h_f_link
+  assumption
+
+/- gist of the proof of the next part:
+Goal: there's a cycle which contains the vertices of the longest path (which we will call P)
+Proof:
+- first, note that each neighbour of P.first must be on P by maximality of P
+- symmetrically, each neighbour of P.last must be on P as well
+- each neighbour of P.first has an edge of P to its left,
+  each neighbour of P.last has an edge of P to its right
+- since min degree >= n/2, there are n/2 edges of P with a neighbour of
+  of P.first on its right and n/2 edges of P with a neighbour of P.last on its left
+- P can only have at most n - 1 edges, so by pigeonhole, there must be at least
+  one edge of P with a neighbour of P.last on its left and a neighbour of P.first on
+  its right, say x - e - y with (G.Adj P.first x), (G.Adj P.last y)
+- so if we let:
+  * u := P.first
+  * v := P.last
+  * P₁ be the prefix u ... x,
+  * P₂ be the suffix y ... v,
+  then P₁ + xv - P₂ + yu is a cycle containing all of V(P)
+-/

--- a/Matroid/Exercises/HamiltonianCycle.lean
+++ b/Matroid/Exercises/HamiltonianCycle.lean
@@ -1583,15 +1583,18 @@ would be less than |C| ≤ n/2.
 -/
 
 omit [DecidableEq α] in
-lemma thm1_1_connected {G : Graph α β} [G.Simple] [hFinite : G.Finite]
-  (hV : 3 ≤ V(G).ncard) (hDegree : V(G).ncard ≤ 2 * G.minDegree) :
+lemma dirac_connected {G : Graph α β} [G.Simple] [hFinite : G.Finite]
+  (hV : 3 ≤ V(G).encard) (hDegree : V(G).encard ≤ 2 * G.minEDegree) :
   G.Connected := by
   have encard_eq_ncard : V(G).encard = ↑V(G).ncard := by
     rw [Set.Finite.cast_ncard_eq]
     exact vertexSet_finite
   have hNeBot : G.NeBot := by
-    apply NeBot_of_ncard_positive
-    linarith
+    rw [NeBot_iff_encard_positive]
+    enat_to_nat! <;> omega
+  simp [← G.natCast_minDegree_eq hNeBot] at hDegree
+  rw [encard_eq_ncard] at hV hDegree
+  enat_to_nat
 
   -- Suppose not.
   by_contra! hyp_contra

--- a/Matroid/Exercises/HamiltonianCycle.lean
+++ b/Matroid/Exercises/HamiltonianCycle.lean
@@ -153,12 +153,51 @@ lemma exists_vertex_minDegree' (hG : V(G).Nonempty) : ∃ x ∈ V(G), G.degree x
 
 -- MORE THINGS
 
-lemma degree_lt_vertexCount [G.Simple] (h : v ∈ V(G)) :
-    G.degree v < V(G).ncard := by sorry
+lemma setOf_adj_subset {G : Graph α β} (x : α) : {y | G.Adj x y} ⊆ V(G) := by
+  intro y hy
+  simp at hy
+  exact hy.right_mem
 
-lemma minDegree_lt_vertexCount [G.Simple] (hNeBot : G.NeBot) : G.minDegree < V(G).ncard := by
+-- maybe this should be `Neighbor`?
+lemma encard_setOf_adj_le {G : Graph α β} [G.Simple] {x : α} (h : x ∈ V(G)) :
+    {y | G.Adj x y}.encard + 1 ≤ V(G).encard := by
+  have : ({x} : Set α).encard = 1 := by simp
+  rw [← this]; clear this
+  rw [←Set.encard_union_eq]
+  swap
+  · simp; apply not_adj_self
+  apply encard_le_encard
+  simp
+  refine insert_subset h ?_
+  exact setOf_adj_subset _
+
+-- by incAdjEquiv
+lemma eDegree_le_encard {G : Graph α β} [G.Simple] {x : α} (h : x ∈ V(G)) :
+    G.eDegree x + 1 ≤ V(G).encard := by
+  have solver := G.incAdjEquiv x
+  simp [eDegree_eq_encard_inc]
+  change {e // e ∈ {e | G.Inc e x}} ≃ {y // y ∈ {y | G.Adj x y}} at solver
+  repeat rw [←coe_eq_subtype] at solver
+  rw [solver.encard_eq]
+  exact encard_setOf_adj_le h
+
+lemma degree_le_ncard {G : Graph α β} [G.Simple] [G.Finite] {x : α} (h : x ∈ V(G)) :
+    G.degree x + 1 ≤ V(G).ncard := by
+  suffices hyp : G.eDegree x + 1 ≤ V(G).encard
+  · rw [←natCast_degree_eq, ←Set.Finite.cast_ncard_eq vertexSet_finite] at hyp
+    enat_to_nat!; assumption
+  exact eDegree_le_encard h
+
+lemma degree_lt_ncard {G : Graph α β} [G.Simple] [G.Finite] {x : α} (h : x ∈ V(G)) :
+    G.degree x < V(G).ncard := by
+  linarith [degree_le_ncard h]
+
+lemma minDegree_lt_ncard {G : Graph α β} [G.Simple] [G.Finite] (hNeBot : G.NeBot) :
+    G.minDegree < V(G).ncard := by
   have ⟨v,hvG, vspec⟩ := G.exists_vertex_minDegree hNeBot
-  exact vspec ▸ degree_lt_vertexCount hvG
+  rw [←vspec]
+  apply degree_lt_ncard
+  tauto
 
 --The exercises start here
 --I added this lemma. Seems important. Do we need to prove it or already exists but is not working?
@@ -1516,12 +1555,12 @@ lemma thm1_1_connected [G.Simple] [hFinite : G.Finite]
 
   -- G, min_comp, other_comp have finite vertexSets
   have G_finite_vertexSet : V(G).Finite := vertexSet_finite
-  have min_comp_finite_vertexSet : V(min_comp).Finite := by
-    suffices min_comp.Finite by exact vertexSet_finite
-    exact Finite.mono hFinite min_comp_spec.1.le
-  have other_comp_finite_vertexSet : V(other_comp).Finite := by
-    suffices other_comp.Finite by exact vertexSet_finite
-    exact Finite.mono hFinite other_comp_spec.1.le
+  have min_comp_finite : min_comp.Finite := hFinite.mono min_comp_spec.1.le
+  have min_comp_finite_vertexSet : V(min_comp).Finite :=
+    vertexSet_finite
+  have other_comp_finite : other_comp.Finite := hFinite.mono other_comp_spec.1.le
+  have other_comp_finite_vertexSet : V(other_comp).Finite :=
+    vertexSet_finite
 
   -- other_comp has at least as many vertices as min_comp
   have other_comp_larger : V(min_comp).ncard ≤ V(other_comp).ncard := by
@@ -1578,8 +1617,8 @@ lemma thm1_1_connected [G.Simple] [hFinite : G.Finite]
     exact min_comp_spec.1
   replace hle : V(min_comp).ncard ≤ min_comp.minDegree := by linarith
   have hlt : min_comp.minDegree < V(min_comp).ncard := by
-    have min_comp_simple : min_comp.Simple := sorry
-    refine minDegree_lt_vertexCount ?_
+    have min_comp_simple : min_comp.Simple := ‹G.Simple›.mono min_comp_spec.1.le
+    refine minDegree_lt_ncard ?_
     rw [NeBot_iff_vertexSet_nonempty]
     exact min_comp_spec.1.nonempty
 

--- a/Matroid/Exercises/HamiltonianCycle.lean
+++ b/Matroid/Exercises/HamiltonianCycle.lean
@@ -305,44 +305,86 @@ lemma unique_neighbor_of_eDegree_eq_one (hx : G.eDegree x = 1) (hxy : G.Adj x y)
   obtain rfl : xz = xy := setOf_inc_le _ hxz.inc_left
   exact hxy.right_unique hxz
 
-lemma exists_isSepSet_of_isTree {T : Graph α β} (hT : T.IsTree) (hV : 3 ≤ V(T).encard) :
+lemma IsTree.exists_vertex_eDegree_ge_two
+    {T : Graph α β} (hT : T.IsTree) (hV : 3 ≤ V(T).encard) :
+    ∃ x ∈ V(T), 2 ≤ T.eDegree x := by
+  have hMinDeg : ∀ x ∈ V(T), 1 ≤ T.eDegree x := by
+    refine minEDegree_ge_one_of_connected_nontrivial hT.connected ?_
+    suffices (1 : ℕ∞) < 3 by
+      exact this.trans_le hV
+    simp
+  by_contra! hyp
+  replace hyp : ∀ x ∈ V(T), T.eDegree x = 1 := by
+    intro x hxT
+    specialize hyp _ hxT
+    specialize hMinDeg _ hxT
+    enat_to_nat! <;> omega
+  clear hMinDeg
+  have hT_nonempty : V(T).Nonempty := by
+    simp only [←Set.encard_pos]
+    enat_to_nat!; omega
+  have ⟨x, hxT⟩ := hT_nonempty
+  have hx_ssub : {x} ⊂ V(T) := by
+    refine ⟨by simp; tauto, ?_⟩
+    intro bad
+    have := Set.encard_le_encard bad
+    simp at this; enat_to_nat!; omega
+  have hconn := hT.connected
+  rw [connected_iff_forall_exists_adj hT_nonempty] at hconn
+  have hy := hconn _ hx_ssub (by simp)
+  simp at hy
+  obtain ⟨y, ⟨hyT, hne⟩, hadj⟩ := hy
+  have hxy_ssub : {x,y} ⊂ V(T) := by
+    refine ⟨?_, ?_⟩
+    · simp [pair_subset_iff]; tauto
+    intro bad
+    have := Set.encard_le_encard bad
+    have := hV.trans this
+    replace hne : x ≠ y := fun a ↦ hne (id (Eq.symm a))
+    simp [Set.encard_pair hne] at this
+    norm_num at this
+  have hz := hconn _ hxy_ssub (by simp)
+  obtain ⟨x', hx', z, hz⟩ := hz
+  apply hz.1.2
+  simp at hx'; obtain (hx'|hx') := hx'
+    <;> symm at hx'
+    <;> subst hx'
+    <;> [(right; simp); (left; symm at hadj)]
+    <;> exact unique_neighbor_of_eDegree_eq_one (hyp _ ‹_›) hz.2 ‹_›
+
+lemma IsTree.exists_length_two_path
+    {T : Graph α β} (hT : T.IsTree) (hV : 3 ≤ V(T).encard) :
+    ∃ P, T.IsPath P ∧ P.length = 2 := by
+  have T_simple := hT.isForest.simple
+  have ⟨x, hxT, hx⟩ : ∃ x ∈ V(T), 2 ≤ T.eDegree x :=
+    hT.exists_vertex_eDegree_ge_two hV
+  rw [eDegree_eq_encard_adj] at hx
+  have ⟨N, hN_sub, hN_encard⟩ := Set.exists_subset_encard_eq hx
+  rw [Set.encard_eq_two] at hN_encard
+  obtain ⟨y,z,hne,rfl⟩ := hN_encard
+  -- pick a path between y and z which does not go through x
+  obtain ⟨hy, hz⟩ : T.Adj x y ∧ T.Adj x z := by
+    refine ⟨hN_sub ?_, hN_sub ?_⟩ <;> simp
+  have ⟨hyT, hzT⟩ : y ∈ V(T) ∧ z ∈ V(T) := by
+    have := T.setOf_adj_subset x
+    refine ⟨?_, ?_⟩  <;>
+      apply this <;> assumption
+  obtain ⟨ey, hey⟩ := hy
+  obtain ⟨ez, hez⟩ := hz
+  refine ⟨cons y ey (cons x ez (nil z)), ?_, by simp⟩
+  simp
+  have hne_xy : x ≠ y := hey.adj.ne
+  have hne_xz : x ≠ z := hez.adj.ne
+  tauto
+
+lemma IsTree.exists_isSepSet
+    {T : Graph α β} (hT : T.IsTree) (hV : 3 ≤ V(T).encard) :
     ∃ S, IsSepSet T S ∧ S.encard = 1 := by
   -- we show there exists a vertex x of degree at least 2, in which case
   -- the singleton {x} is exactly our sepset
-  have ⟨x, hxT, hx⟩ : ∃ x ∈ V(T), 2 ≤ T.eDegree x := by
-    by_contra! hyp
-    replace hyp : ∀ x ∈ V(T), T.eDegree x = 1 := by
-      intro x hxT
-      specialize hyp _ hxT
-      specialize hMinDeg _ hxT
-      enat_to_nat! <;> omega
-    clear hMinDeg
-    have hT_nonempty : V(T).Nonempty := by
-      simp only [←Set.encard_pos]
-      enat_to_nat!; omega
-    have ⟨x, hxT⟩ := hT_nonempty
-    have hx_ssub : {x} ⊂ V(T) := by
-      refine ⟨by simpa, fun bad ↦ ?_⟩
-      simpa using hV.trans <| encard_le_encard bad
-    have hconn := hT.connected
-    rw [connected_iff_forall_exists_adj hT_nonempty] at hconn
-    obtain ⟨y, ⟨hyT, hne⟩, hadj⟩ := by simpa using hconn _ hx_ssub (by simp)
-    have hxy_ssub : {x, y} ⊂ V(T) := by
-      refine ⟨?_, fun bad ↦ ?_⟩
-      · simp [pair_subset_iff, hxT, hyT]
-      have := Set.encard_le_encard bad
-      have := hV.trans this
-      replace hne : x ≠ y := fun a ↦ hne (id (Eq.symm a))
-      simp [Set.encard_pair hne] at this
-      norm_num at this
-    have hz := hconn _ hxy_ssub (by simp)
-    obtain ⟨x', hx', z, hz⟩ := hz
-    apply hz.1.2
-    simp at hx'; obtain (hx'|hx') := hx'
-      <;> symm at hx'
-      <;> subst hx'
-      <;> [(right; simp); (left; symm at hadj)]
-      <;> exact unique_neighbor_of_eDegree_eq_one (hyp _ ‹_›) hz.2 ‹_›
+  have ⟨x, hxT, hx⟩ : ∃ x ∈ V(T), 2 ≤ T.eDegree x :=
+    hT.exists_vertex_eDegree_ge_two hV
+
   -- now we have our vertex x of degree ≥ 2
   refine ⟨{x}, ?_, by simp⟩
   simp only [IsSepSet, singleton_subset_iff]

--- a/Matroid/Exercises/HamiltonianCycle.lean
+++ b/Matroid/Exercises/HamiltonianCycle.lean
@@ -295,18 +295,12 @@ lemma exists_isSepSet_of_isTree {T : Graph α β} (hT : T.IsTree) (hV : 3 ≤ V(
     replace hyp : ∀ x ∈ V(T), T.eDegree x = 1 := by
       intro x hxT
       specialize hyp _ hxT
-      have hMinDeg : 1 ≤ T.eDegree x := by
-        refine minEDegree_ge_one_of_connected_nontrivial hT.connected ?_ _ hxT
-        suffices (1 : ℕ∞) < 3 by
-          exact this.trans_le hV
-        simp
-      change T.eDegree x < 1 + 1 at hyp
-      rw [ENat.lt_add_one_iff] at hyp <;> [exact hyp.antisymm hMinDeg; simp]
+      specialize hMinDeg _ hxT
+      enat_to_nat! <;> omega
+    clear hMinDeg
     have hT_nonempty : V(T).Nonempty := by
       simp only [←Set.encard_pos]
-      suffices (0 : ℕ∞) < 3 by
-        exact this.trans_le hV
-      simp
+      enat_to_nat!; omega
     have ⟨x, hxT⟩ := hT_nonempty
     have hx_ssub : {x} ⊂ V(T) := by
       refine ⟨by simpa, fun bad ↦ ?_⟩
@@ -1558,8 +1552,7 @@ lemma thm1_1_connected {G : Graph α β} [G.Simple] [hFinite : G.Finite]
     have : G.Components.encard = 1 := by
       simp [is_singleton]
     rw [this] at num_components_ge_2; clear this
-    have : (2 : ℕ) ≤ (1 : ℕ) := by exact ENat.coe_le_coe.mp num_components_ge_2
-    linarith
+    enat_to_nat; omega
 
   -- G, min_comp, other_comp have finite vertexSets
   have G_finite_vertexSet : V(G).Finite := vertexSet_finite

--- a/Matroid/Exercises/HamiltonianCycle.lean
+++ b/Matroid/Exercises/HamiltonianCycle.lean
@@ -2271,6 +2271,9 @@ lemma dirac_exists_cycle
   obtain ⟨x, ex, hx⟩ := x
   simp at h_dinc
   have decEqα := Classical.decEq α
+  clear left_edge_spec left_edge_inj left_edge_range_le he_left left_edge
+  clear right_edge_spec right_edge_inj right_edge_range_le he_right right_edge
+  clear equiv_first equiv_last
 
   -- Two trivial cases: when ex ∈ P.edge or when ey ∈ P.edge.
   -- In either case, we can directly close the path up.


### PR DESCRIPTION
This is a really half-assed job, really quite unfortunate. Since we directly pushed a copy of `HamiltonianCycle.lean` into `main` by just copy-pasting, the copy of the file on `main` doesn't share the pre-existing git history. Thankfully, commits `19275f3` (on `main`) and `39c64ff` (on `DRP-exercises`) have the same file state, so it's possible to use `git replace` to get `git rebase` to behave a little more sensibly. But due to my lacking git skills, we're still left in a state where the entire rest of the file's history has just poofed out of existence. 

On the bright side, it builds! 